### PR TITLE
Potential fix for code scanning alert no. 6: First parameter of a method is not named 'self'

### DIFF
--- a/tests/test_netshield.py
+++ b/tests/test_netshield.py
@@ -1505,7 +1505,7 @@ class TestWriteIpListCleanup(unittest.TestCase):
         try:
             # Iterator, der einen RuntimeError wirft
             class BadIter:
-                def __iter__(self_inner):
+                def __iter__(self):
                     yield "1.1.1.1"
                     raise RuntimeError("Feed-Crash")
 


### PR DESCRIPTION
Potential fix for [https://github.com/juergen2025sys/NETSHIELD/security/code-scanning/6](https://github.com/juergen2025sys/NETSHIELD/security/code-scanning/6)

To fix this, rename the first parameter of the inner instance method `BadIter.__iter__` from `self_inner` to `self` in `tests/test_netshield.py` (around line 1508). This preserves behavior and satisfies PEP 8 / CodeQL expectations for normal instance methods.

Only one code edit is needed:
- In `TestWriteIpListCleanup.test_cleanup_tolerates_unlink_error`, inside the local class `BadIter`, change:
  - `def __iter__(self_inner):`
  - to `def __iter__(self):`

No imports, decorators, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
