### PR TITLE
Potential fix for code scanning alert no. 41: Imprecise assert

### DIFF
--- a/tests/test_project_audit_fixes.py
+++ b/tests/test_project_audit_fixes.py
@@ -80,7 +80,9 @@ class ProjectAuditTests(unittest.TestCase):
             with self.subTest(workflow=workflow, step=name):
                 sequence = steps(workflow)
                 step = next(step for step in sequence if step.get('name') == name)
-                self.assertTrue(set(required) <= {step.get('id') for step in sequence})
+                step_ids = {step.get('id') for step in sequence}
+                missing = set(required) - step_ids
+                self.assertEqual(missing, set())
                 ok = dict.fromkeys(required, 'success')
                 self.assertTrue(eligible(step['if'], ok))
                 for dependency in required:


### PR DESCRIPTION
Potential fix for [https://github.com/juergen2025sys/NETSHIELD/security/code-scanning/41](https://github.com/juergen2025sys/NETSHIELD/security/code-scanning/41)

Replace the imprecise `assertTrue(subset_check)` with a more specific assertion that reports exactly what is missing.  
In `tests/test_project_audit_fixes.py` at the test `test_publications_require_build_and_validation_success`, line 83 region:

- Compute the set of step IDs once (currently built inline).
- Assert that all `required` IDs are present by checking the set difference is empty:
  - `missing = set(required) - step_ids`
  - `self.assertEqual(missing, set())`

This preserves functionality (still fails when required IDs are absent) and provides a much clearer failure message showing missing IDs.

No imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
